### PR TITLE
cloud-init/daily_deb.sh: wait for cloud-init to finish.

### DIFF
--- a/cloud-init/daily_deb.sh
+++ b/cloud-init/daily_deb.sh
@@ -53,13 +53,14 @@ start_container() {
     CONTAINER=$name
 
     local out="" ret=""
-    debug 1 "waiting for networking"
+    debug 1 "waiting for boot to finish."
     out=$(inside "$name" sh -c '
         i=0
         while [ $i -lt 60 ]; do
-            getent hosts archive.ubuntu.com && exit 0
+            [ -f /run/cloud-init/result.json ] && exit 0
             sleep 2
-        done 2>&1')
+        done 2>&1
+        exit 1')
     ret=$?
     if [ $ret -ne 0 ]; then
         error "Waiting for network in container '$name' failed. [$ret]"


### PR DESCRIPTION
The change here makes daily_deb wait until cloud-init is finished
before it starts operating.

We had a very odd failure:
  :: adding cloud-init daily PPA
  E: Type 'curity' is not known on line 50 in source list
    /etc/apt/sources.list
  E: The list of sources could not be read.
  failed: adding cloud-init daily PPA

The suspected reason is that cloud-init was editing /etc/apt/sources.list
at the same time that the daily_deb script ran 'apt-get update'.