### PR TITLE
cloud-init/daily_deb.sh: wait 120s for boot of container.

### DIFF
--- a/cloud-init/daily_deb.sh
+++ b/cloud-init/daily_deb.sh
@@ -72,6 +72,7 @@ main() {
     set -- \
         ./ctool run-container --verbose --destroy "--name=$name" \
         --as-root --artifacts=. "--copy-out=download/" \
+        --boot-wait=120 \
         -- "ubuntu-daily:$release" bash -s download
     error "executing: $* <'$0'"
     "$@" < "$0" || fail "failed executing $* < '$0'"


### PR DESCRIPTION
Bug 1796137 meant that cosmic containers were not booting in the
default 30 seconds.  The change here just waits up to 120s for the
container to boot before using it.