### PR TITLE
Fix the Copr build and test scripts

### DIFF
--- a/cloud-init/copr_build.py
+++ b/cloud-init/copr_build.py
@@ -16,7 +16,7 @@ import copr
 
 ID_CLOUD_INIT = 13995
 ID_CLOUD_INIT_DEV = 14567
-TEST_CHROOTS = ['epel-6-x86_64', 'epel-7-x86_64']
+TEST_CHROOTS = ['epel-7-x86_64']
 URL_COPR = "https://copr.fedorainfracloud.org/coprs/g/cloud-init"
 
 DEFAULT_COPR_CONF = os.path.expanduser('~/.config/copr')

--- a/cloud-init/copr_test
+++ b/cloud-init/copr_test
@@ -73,6 +73,7 @@ start_container() {
         debug 1 "configuring proxy ${http_proxy}"
         inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
         inside "$name" sed -i s/enabled=1/enabled=0/ /etc/yum/pluginconf.d/fastestmirror.conf
+        inside "$name" sh -c "sed -i '/^#baseurl=/s/#//' /etc/yum.repos.d/*.repo"
     fi
 }
 


### PR DESCRIPTION
Disable the epel-6 build and enable the `baseurl` repository when using an http proxy.