### PR TITLE
bootspeed ec2: fix the logging of the image serial

### DIFF
--- a/boot-speed/clouds/measure-cloud.py
+++ b/boot-speed/clouds/measure-cloud.py
@@ -141,7 +141,7 @@ def cloudid2serial(id):
     )
     filters = ['id=%s' % id]
     res = stream.query(filters)
-    id = res[0]['id']
+    id = res[0]['version_name']
     return id
 
 


### PR DESCRIPTION
The image ID (ami-*) was incorrectly logged instead.