### PR TITLE
bootspeed: workaround LP: #1832386

### DIFF
--- a/boot-speed/clouds/measure-cloud.py
+++ b/boot-speed/clouds/measure-cloud.py
@@ -56,7 +56,11 @@ class EC2Instspec:
         ec2 = pycloudlib.EC2(tag='bootspeed', region=self.region)
 
         if self.inst_type.split('.')[0] == 'a1':
-            daily = ec2.daily_image(release=self.release, arch='arm64')
+            if self.release == 'xenial' or self.release == 'bionic':
+                # Workaround for LP: #1832386
+                daily = ec2.released_image(release=self.release, arch='arm64')
+            else:
+                daily = ec2.daily_image(release=self.release, arch='arm64')
         else:
             daily = ec2.daily_image(release=self.release)
 


### PR DESCRIPTION
* workaround LP: #1832386 by pulling images from the 'releases' stream
   for Xenial and Bionic on EC2 A1 instances
 * drop the cloud2serial() function and switch to pycloudlib's newly
   implemented image_serial() function, which also handles images from the
   'releases' stream.