### PR TITLE
bootspeed: use the Core18 beta images, plus minor improvements

### DIFF
--- a/boot-speed/testflinger/dragonboard410c-core18.provision.yaml
+++ b/boot-speed/testflinger/dragonboard410c-core18.provision.yaml
@@ -1,3 +1,3 @@
 job_queue: dragonboard
 provision_data:
-    url: http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz
+    url: http://cdimage.ubuntu.com/ubuntu-core/18/beta/current/ubuntu-core-18-arm64+snapdragon.img.xz

--- a/boot-speed/testflinger/measure-device.sh
+++ b/boot-speed/testflinger/measure-device.sh
@@ -65,6 +65,10 @@ fi
 
 cat "$yaml_head" "$yaml_tail" > "$yaml_full"
 
+echo "=== Testflinger yaml ==="
+cat "$yaml_full"
+echo "=== End of testflinger yaml ==="
+
 job_id=$(testflinger-cli submit --quiet "$yaml_full")
 
 echo "testflinger job_id: $job_id"

--- a/boot-speed/testflinger/measure-device.sh
+++ b/boot-speed/testflinger/measure-device.sh
@@ -23,7 +23,7 @@ yaml_head="$scriptpath/$device-$distro.provision.yaml"
 yaml_tail="$scriptpath/test_data.yaml"
 yaml_full="$device-$distro.full.yaml"
 
-yyyymmdd=$(date --utc '+%Y%m%d')
+yyyymmdd=$(date --utc '+%Y%m%d%H%M%S')
 date_rfc3339=$(date --utc --rfc-3339=ns)
 
 echo "Target device: $device"

--- a/boot-speed/testflinger/rpi3b-core18.provision.yaml
+++ b/boot-speed/testflinger/rpi3b-core18.provision.yaml
@@ -1,3 +1,3 @@
 job_queue: rpi3b
 provision_data:
-    url: http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz
+    url: http://cdimage.ubuntu.com/ubuntu-core/18/beta/current/ubuntu-core-18-armhf+raspi3.img.xz


### PR DESCRIPTION
Changes for devices:
 * pull the Core18 beta images when testing devices
 * name the files with a timestamp up to the second (like for the clouds)
 * print the testflinger yaml file before submitting it (for debugging)

"current" Core16 beta images are not available yet.