### PR TITLE
bootspeed: add support for LXD and KVM instances

### DIFF
--- a/boot-speed/bootspeed.sh
+++ b/boot-speed/bootspeed.sh
@@ -58,7 +58,6 @@ fi
 systemd-analyze time > systemd-analyze_time
 systemd-analyze blame > systemd-analyze_blame
 systemd-analyze critical-chain > systemd-analyze_critical-chain
-systemd-analyze plot > systemd-analyze_plot.svg
 
 # Gather additional data
 cp -v /etc/fstab .

--- a/boot-speed/clouds/.gitignore
+++ b/boot-speed/clouds/.gitignore
@@ -1,0 +1,2 @@
+bootspeed-*
+*.tar.gz

--- a/boot-speed/testflinger/measure-device.sh
+++ b/boot-speed/testflinger/measure-device.sh
@@ -83,7 +83,7 @@ fi
 echo
 echo "### POLLING $job_id"
 echo
-if ! timeout 2h testflinger-cli poll "$job_id"; then
+if ! timeout 16h testflinger-cli poll "$job_id"; then
     echo "testflinger-cli timeout"
     testflinger-cli cancel "$job_id" || true
     exit 1


### PR DESCRIPTION
Other minor changes:
 - EC2: add command line parameters to specify the SSH keypair to use
 - devices: bump the testflinger timeout to 16h
 - all: do not call `systemd-analyze plot`
 - all: add a .gitignore