### PR TITLE
ec2_cleanup: improve the script logic

### DIFF
--- a/boot-speed/clouds/ec2_cleanup.py
+++ b/boot-speed/clouds/ec2_cleanup.py
@@ -5,44 +5,61 @@ Copyright 2018-2019 Canonical Ltd.
 Joshua Powers <josh.powers@canonical.com>
 Paride Legovini <paride.legovini@canonical.com>
 """
+
 import boto3
 import datetime as dt
 import os
 import re
 
+from botocore.exceptions import WaiterError
+
 
 def clean_ec2():
     """Clean up all running EC2 instances tagged 'bootspeed-*'."""
-
     # Maximum instance age (in minutes)
-    max_inst_age = os.environ.get('MAX_EC2_INST_AGE', 120)
+    max_inst_age = int(os.environ.get('MAX_EC2_INST_AGE', 120))
 
     # Seconds since epoch; will be compared with the timestamp we put
     # in the instance tag to determine if instances are stale.
     now = int(dt.datetime.utcnow().timestamp())
 
+    print("Max allowed age of instances: %d minutes" % max_inst_age)
+
     resource = boto3.resource('ec2')
     inst_tag = [{'Name': 'tag:Name', 'Values': ['bootspeed-*']}]
-    stale_instances = []
+    stale_instances = set()
     for vpc in list(resource.vpcs.all()):
-        print('# cleaning up vpc %s\n' % vpc.id)
+        print('Cleaning up vpc %s' % vpc.id)
         for instance in vpc.instances.filter(Filters=inst_tag):
             for tag in instance.tags:
                 if tag['Key'] == 'Name' and re.match(
                         "^bootspeed-[0-9]+$", tag['Value']):
-                    print('Found bootspeed instance %s' % instance.id)
+                    print('- Found bootspeed instance %s' % instance.id)
                     timestamp = int(tag['Value'].split("-")[1])
                     tdelta = now - timestamp
-                    print('Instance started %s seconds ago' % tdelta)
+                    print('  Instance started %s seconds ago' % tdelta)
                     if tdelta > max_inst_age*60:
-                        print("Terminating stale instance.")
-                        stale_instances.append(instance)
+                        print("  Stale instance, terminating.")
+                        stale_instances.add(instance)
                         instance.terminate()
-                    print()
+                    break
 
     for instance in stale_instances:
-        print("Waiting for %s to be terminated." % instance.id)
-        instance.wait_until_terminated()
+        print("Waiting for %s to be terminated" % instance.id)
+
+        # On metal instances wait_until_terminated() sometimes fails, likely
+        # because of the long reaction times of such instances. Versions
+        # botocore/boto3 newer than the one in Bionic may behave better
+        # from this point of view. Here we work around the issue by retrying
+        # wait_until_terminated() in case of WaiterError.
+        #
+        # This is not nice, but the critical thing here is to be sure not to
+        # leave lingering instances.
+        try:
+            instance.wait_until_terminated()
+        except WaiterError:
+            print("- WaiterError, trying again.")
+            instance.wait_until_terminated()
 
     print("Done")
 


### PR DESCRIPTION
- MAX_EC2_INST_AGE: cast to int
 - Use a set for stale_instances
 - break the inner for loop after the first 'Name' tag matching
   'bootspeed-*' is found
 - Retry wait_until_terminated() once if it fails
 - Nicer script output