### PR TITLE
Revert "bootspeed.sh: do not call `systemd-analyze plot`"

### DIFF
--- a/boot-speed/bootspeed.sh
+++ b/boot-speed/bootspeed.sh
@@ -58,6 +58,7 @@ fi
 systemd-analyze time > systemd-analyze_time
 systemd-analyze blame > systemd-analyze_blame
 systemd-analyze critical-chain > systemd-analyze_critical-chain
+systemd-analyze plot > systemd-analyze_plot.svg
 
 # Gather additional data
 cp -v /etc/fstab .


### PR DESCRIPTION
This reverts commit 841f1b672828ff7a5d7de4865853159844499f98.

The collection of the `systemd-analyze plot` SVGs was disabled because
they often take more space than all the other measurement artifacts
combined, and we are not immediately using them. However it may be
worth collecting them to ease the analysis of the boot process.