### PR TITLE
cloud-init copr: the main build target OS is now CentOS 8

### DIFF
--- a/cloud-init/copr_build.py
+++ b/cloud-init/copr_build.py
@@ -120,7 +120,7 @@ def main(srpm, copr_conf=DEFAULT_COPR_CONF, dev=None):
 
     # 2018-03-05: adding sleep to let builds ramp up
     # this after a {'state': ['Not a valid choice.']} exception
-    time.sleep(120)
+    time.sleep(180)
 
     tasks = get_build_tasks(build)
     check_build_status(build, tasks)

--- a/cloud-init/copr_build.py
+++ b/cloud-init/copr_build.py
@@ -16,7 +16,7 @@ import copr
 
 ID_CLOUD_INIT = 13995
 ID_CLOUD_INIT_DEV = 14567
-TEST_CHROOTS = ['epel-7-x86_64']
+TEST_CHROOTS = ['epel-8-x86_64']
 URL_COPR = "https://copr.fedorainfracloud.org/coprs/g/cloud-init"
 
 DEFAULT_COPR_CONF = os.path.expanduser('~/.config/copr')


### PR DESCRIPTION
Changes:
 - use epel-8-x86_64 as the test chroot
 - increase the wait time before checking the build tasks